### PR TITLE
Remove manual native memory management methods from API

### DIFF
--- a/src/main/java/com/sernamar/jgit2/Commit.java
+++ b/src/main/java/com/sernamar/jgit2/Commit.java
@@ -47,21 +47,6 @@ public final class Commit {
     }
 
     /**
-     * Close an open commit
-     * <p>
-     * This is a wrapper around git_object_free()
-     * <p>
-     * IMPORTANT:
-     * It *is* necessary to call this method when you stop
-     * using a commit. Failure to do so will cause a memory leak.
-     *
-     * @param commit the commit to close
-     */
-    public static void gitCommitFree(GitCommit commit) {
-        git_commit_free(commit.segment());
-    }
-
-    /**
      * Create new commit in the repository using a variable argument list.
      * <p>
      * The message will **not** be cleaned up automatically. You can do that

--- a/src/main/java/com/sernamar/jgit2/Oid.java
+++ b/src/main/java/com/sernamar/jgit2/Oid.java
@@ -75,15 +75,6 @@ public final class Oid {
     }
 
     /**
-     * Free an OID shortener.
-     *
-     * @param shortenerId the OID shortener.
-     */
-    public static void gitOidShortenFree(GitOidShorten shortenerId) {
-        git_oid_shorten_free(shortenerId.segment());
-    }
-
-    /**
      * Add a new OID to set of shortened OIDs and calculate
      * the minimal length to uniquely identify all the OIDs in
      * the set.

--- a/src/main/java/com/sernamar/jgit2/Repository.java
+++ b/src/main/java/com/sernamar/jgit2/Repository.java
@@ -81,21 +81,6 @@ public final class Repository {
     }
 
     /**
-     * Free a previously allocated repository
-     * <p>
-     * Note that after a repository is freed, all the objects it has spawned
-     * will still exist until they are manually closed by the user
-     * with `git_object_free`, but accessing any of the attributes of
-     * an object without a backing repository will result in undefined
-     * behavior
-     *
-     * @param repo repository handle to close. If NULL nothing occurs.
-     */
-    public static void gitRepositoryFree(GitRepository repo) {
-        git_repository_free(repo.segment());
-    }
-
-    /**
      * Get the Index file for this repository.
      * <p>
      * If a custom index has not been set, the default

--- a/src/test/java/com/sernamar/jgit2/RepositoryTest.java
+++ b/src/test/java/com/sernamar/jgit2/RepositoryTest.java
@@ -54,12 +54,6 @@ class RepositoryTest {
     }
 
     @Test
-    void gitRepositoryFree() {
-        GitRepository repo = Repository.gitRepositoryInit(PATH);
-        Repository.gitRepositoryFree(repo);
-    }
-
-    @Test
     void gitRepositoryIndex() {
         try (GitRepository repo = Repository.gitRepositoryInit(PATH);
              GitIndex index = Repository.gitRepositoryIndex(repo)) {


### PR DESCRIPTION
Some methods, like `gitRepositoryFree`, `gitCommitFree`, and `gitOidShortenFree`, were added to mirror the C API by wrapping functions that free native memory. However, manual memory management is unnecessary in Java, which runs on the JVM and relies on garbage collection.

So this PR removes these methods, and instead resource cleanup will be handled exclusively through `AutoCloseable` and the `close()` method.

Users should use `try-with-resources` or call `close()` explicitly.