### PR TITLE
Fix double-free issue in `GitSignature` by tracking ownership

### DIFF
--- a/src/main/java/com/sernamar/jgit2/Commit.java
+++ b/src/main/java/com/sernamar/jgit2/Commit.java
@@ -134,7 +134,7 @@ public final class Commit {
      * @return the committer of a commit
      */
     public static GitSignature gitCommitCommitter(GitCommit commit) {
-        return new GitSignature(git_commit_committer(commit.segment()));
+        return new GitSignature(git_commit_committer(commit.segment()), false);
     }
 
     /**
@@ -144,6 +144,6 @@ public final class Commit {
      * @return the author of a commit
      */
     public static GitSignature gitCommitAuthor(GitCommit commit) {
-        return new GitSignature(git_commit_author(commit.segment()));
+        return new GitSignature(git_commit_author(commit.segment()), false);
     }
 }

--- a/src/main/java/com/sernamar/jgit2/GitSignature.java
+++ b/src/main/java/com/sernamar/jgit2/GitSignature.java
@@ -5,12 +5,23 @@ import com.sernamar.jgit2.bindings.git_signature;
 import java.lang.foreign.MemorySegment;
 
 import static com.sernamar.jgit2.bindings.git2_1.git_signature_free;
-
+/*
+`GitSignature` objects can be created in two ways:
+1. Using functions like `gitSignatureNew`, `gitSignatureNow`, or `gitSignatureDefault`, that create signatures that
+ are owned by the caller.
+2. Using functions like `gitCommitAuthor`, `gitCommitCommiter`, `gitSignatureLookup`, etc., that return signatures that
+ are not owned by the caller.
+The `owned` field indicates whether the `GitSignature` object is owned by the caller or not.
+Only `GitSignature` objects that are owned by the caller should be freed using `git_signature_free`, which is called in the
+`close` method.
+ */
 public final class GitSignature implements AutoCloseable {
     private MemorySegment segment;
+    private final boolean owned;
 
-    GitSignature(MemorySegment segment) {
+    GitSignature(MemorySegment segment, boolean owned) {
         this.segment = segment;
+        this.owned = owned;
     }
 
     MemorySegment segment() {
@@ -27,7 +38,7 @@ public final class GitSignature implements AutoCloseable {
 
     @Override
     public void close() {
-        if (segment != MemorySegment.NULL) {
+        if (owned && segment != MemorySegment.NULL) {
             git_signature_free(segment);
             segment = MemorySegment.NULL;
         }

--- a/src/main/java/com/sernamar/jgit2/Signature.java
+++ b/src/main/java/com/sernamar/jgit2/Signature.java
@@ -39,7 +39,7 @@ public final class Signature {
             throw new RuntimeException("Failed to create signature: " + getGitErrorMessage());
         }
         MemorySegment signatureSegment = signaturePtr.get(C_POINTER,0);
-        return new GitSignature(signatureSegment);
+        return new GitSignature(signatureSegment, true);
     }
 
     /**

--- a/src/test/java/com/sernamar/jgit2/CommitTest.java
+++ b/src/test/java/com/sernamar/jgit2/CommitTest.java
@@ -99,8 +99,8 @@ class CommitTest {
         try (GitRepository repo = Repository.gitRepositoryOpen(PATH)) {
             GitOid referenceId = Refs.gitReferenceNameToId(repo, "HEAD");
             assert referenceId != null;
-            try (GitCommit commit = Commit.gitCommitLookup(repo, referenceId)) {
-                GitSignature committer = Commit.gitCommitCommitter(commit);
+            try (GitCommit commit = Commit.gitCommitLookup(repo, referenceId);
+                 GitSignature committer = Commit.gitCommitCommitter(commit)) {
                 assertNotNull(committer);
                 assertEquals(TestUtils.NAME, committer.name());
                 assertEquals(TestUtils.EMAIL, committer.email());
@@ -113,8 +113,8 @@ class CommitTest {
         try (GitRepository repo = Repository.gitRepositoryOpen(PATH)) {
             GitOid referenceId = Refs.gitReferenceNameToId(repo, "HEAD");
             assert referenceId != null;
-            try (GitCommit commit = Commit.gitCommitLookup(repo, referenceId)) {
-                GitSignature author = Commit.gitCommitAuthor(commit);
+            try (GitCommit commit = Commit.gitCommitLookup(repo, referenceId);
+                 GitSignature author = Commit.gitCommitAuthor(commit)) {
                 assertNotNull(author);
                 assertEquals(TestUtils.NAME, author.name());
                 assertEquals(TestUtils.EMAIL, author.email());


### PR DESCRIPTION
#### Problem
Previously, the `GitSignature` class always called `git_signature_free()` in its `close()` method. However, some `GitSignature` instances are owned by their parent objects and should not be freed manually. This caused a double-free error, leading to segmentation faults (SIGSEGV) and JVM crashes.

#### Ownership Differences
Some functions return owned `GitSignature` objects, meaning the caller is responsible for freeing them:
- `git_signature_new()`
- `git_signature_now()`
- `git_signature_dup()`

Other functions return unowned `GitSignature` objects, which are managed by their parent objects and must not be freed manually:
- `git_commit_author()`
- `git_commit_committer()`
- `git_note_author()`
- `git_note_committer()`
- `git_reflog_entry_committer()`
- `git_tag_tagger()`

#### Solution
This PR introduces an `owned` flag in the `GitSignature` class.
- If `owned` is `true`, the object will be freed in `close()`.
- If `owned` is `false`, `close()` will not free it, preventing double-free crashes.

This ensures that only owned signatures are freed while preventing memory leaks.